### PR TITLE
matched database name with script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run the example with a local PostgreSQL DB in docker create a `default-env.js
   "VCAP_SERVICES": {
     "postgres": [
       {
-        "name": "postgres",
+        "name": "db",
         "label": "postgres",
         "tags": ["plain"],
         "credentials": {


### PR DESCRIPTION
Hi Gregor
Tyny change but gave me a bit of a headache.
The name in **VCAP_SERVICES** must match the service deployed
Default is db and we don't specify another in the command line

PS: **default-env.json** is deprecated. I got it to work with .env:
```
cds.requires.db = { "name": "postgres", "label": "postgres", "tags": ["plain"], "credentials": { "host": "localhost", "port": "5432", "database": "beershop","dbname":"beershop", "user": "postgres", "password": "postgres" } }
```
but only if I set dbname too :)