### PR TITLE
Update xs-security.json

### DIFF
--- a/xs-security.json
+++ b/xs-security.json
@@ -20,7 +20,7 @@
     "redirect-uris": [
       "https://*.ondemand.com/**",
       "https://*.computerservice-wolf.com/**",
-      "http://*.computerservice-wolf.com/**"
+      "http://*.localhost/**"
     ]
   }
 }


### PR DESCRIPTION
fix: (xs-security.json): Change oauth2 redirect uris, as http is only allowed for localhost

```she
Service operation failed: Controller operation failed: 502 Updating service "pg-beershop-uaa" failed: 
Bad Gateway: Error creating service "pg-beershop-uaa" from offering "xsuaa" and plan "application": 
CF-ServiceBrokerRequestRejected(10001): Service broker error: Service broker xsuaa failed with: 
Error creating application null (Error parsing xs-security.json data: Malformed redirect URIs detected. 
For the following URIs that use 'http://' only 'localhost' is allowed as last domain: [http://*.computerservice-wolf.com/**]) 
```